### PR TITLE
Added config param to enable/disable layer group visibility toggling

### DIFF
--- a/dev/config/nywebbkarta.json
+++ b/dev/config/nywebbkarta.json
@@ -330,6 +330,7 @@
             "wfs": null,
             "metadataUrl": null,
             "isGroupLayer": true,
+            "toggleGroupEnabled": false,
             "queryable": false,
             "clickable": false,
             "expanded": true,

--- a/src/main/javascript/config/Parser.js
+++ b/src/main/javascript/config/Parser.js
@@ -351,6 +351,7 @@ Ext.define('OpenEMap.config.Parser', {
         if(layer.layers && (Object.prototype.toString.call(layer.layers) === '[object Array]') && layer.layers.length > 0) {
             layer.isGroupLayer = true;
             layer.expanded = layer.expanded === undefined ? true : layer.expanded;
+            layer.toggleGroupEnabled = layer.toggleGroupEnabled === undefined ? true : layer.toggleGroupEnabled;
             layer.layers.forEach(arguments.callee, this);
         } else {
             // If no sublayers, this is a leaf

--- a/src/main/javascript/model/GroupedLayerTreeModel.js
+++ b/src/main/javascript/model/GroupedLayerTreeModel.js
@@ -30,6 +30,7 @@ Ext.define('OpenEMap.model.GroupedLayerTreeModel' ,{
     	{ name: 'queryable', type: 'boolean' },
     	{ name: 'clickable', type: 'boolean' },
     	{ name: 'isGroupLayer', type: 'boolean' },
+        { name: 'toggleGroupEnabled', type: 'boolean'},
     	{ name: 'expanded', type: 'boolean' },
 
         { name: 'layerId' },

--- a/src/main/javascript/view/layer/Tree.js
+++ b/src/main/javascript/view/layer/Tree.js
@@ -39,8 +39,15 @@ Ext.define('OpenEMap.view.layer.Tree' ,{
         }
 
         this.on('checkchange', function(node, checked, eOpts) {
+            // If group layer visibility toggling is disabled, do not handle this click
+            if(node.data.isGroupLayer && !node.data.toggleGroupEnabled) {
+                node.set('checked', !checked);
+                return;
+            }
+
             // Loop this node and children
             node.cascadeBy(function(n){
+
                 n.set('checked', checked);
                 var olLayerRef = n.get('layer');
                 // Change layer visibility (Layer groups have no layer reference)
@@ -57,6 +64,7 @@ Ext.define('OpenEMap.view.layer.Tree' ,{
            
            	function checkParent(n, checked) {
 	            var parent = n.parentNode;
+
 	            if (parent.get("checked") != n.get("checked")) {
 		           	if (checked) {
 		           	    // check parent if not root


### PR DESCRIPTION
New map json config parameter name is "toggleGroupEnabled". If not defined in the layer config it defaults to true.
