### PR TITLE
Use gui options from config if available (#251)

### DIFF
--- a/src/main/javascript/Client.js
+++ b/src/main/javascript/Client.js
@@ -120,11 +120,14 @@ Ext.define('OpenEMap.Client', {
         Ext.tip.QuickTipManager.init();
         
         var parser = Ext.create('OpenEMap.config.Parser');
+        
+        var gui = config.gui || {};
+        Ext.merge(gui, options.gui);
 
         this.map = parser.parse(config);
         this.gui = Ext.create('OpenEMap.Gui', {
             config: config,
-            gui: options.gui,
+            gui: gui,
             map: this.map,
             client: this,
             orginalConfig: this.initialConfig


### PR DESCRIPTION
Resolves #251. Will use config.gui as defaults and override those with what is supplies as options.gui.